### PR TITLE
Wire up admin UI and widget build

### DIFF
--- a/BE/src/index.js
+++ b/BE/src/index.js
@@ -19,16 +19,16 @@ app.use('/api/bots', require('./routes/bots'));
 app.use('/api/conversations', require('./routes/conversations'));
 
 // Serve widget bundle (built assets)
-app.use('/widget', express.static(path.join(__dirname, '../../widget/dist')));
+app.use('/widget', express.static(path.join(__dirname, '../../vit/dist')));
 app.get('/embed', (req, res) => {
     // Minimal page hosting the widget iframe app
-    res.sendFile(path.join(__dirname, '../../widget/dist/index.html'));
+    res.sendFile(path.join(__dirname, '../../vit/dist/index.html'));
 });
 
 // Tiny CDN endpoint for single-line script
 app.get('/cb.js', (req, res) => {
-    // This file can be the minified loader from widget/dist/loader.js
-    res.sendFile(path.join(__dirname, '../../widget/dist/loader.js'));
+    // This file can be the minified loader from vit/dist/loader.js
+    res.sendFile(path.join(__dirname, '../../vit/dist/loader.js'));
 });
 
 async function start() {

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This repository contains a minimal MERN‑stack chatbot platform. It lets you:
    cd vit
    npm run build
    ```
-   The compiled files are output to `widget/dist/`.
+   The compiled files are output to `vit/dist/`.
 
 3. **Start the backend**
    ```bash

--- a/vit/src/App.jsx
+++ b/vit/src/App.jsx
@@ -1,17 +1,10 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
-import ChatWidget from './ChatWidget'
+import ChatWidget from './ChatWidget';
+import BotsList from './pages/BotsList';
+import CreateBot from './pages/CreateBot';
 
-function App() {
-  const [count, setCount] = useState(0)
-
-  return (
-    <>
-      <ChatWidget />
-    </>
-  )
+export default function App() {
+  const path = window.location.pathname;
+  if (path.startsWith('/admin/create')) return <CreateBot />;
+  if (path.startsWith('/admin')) return <BotsList />;
+  return <ChatWidget />;
 }
-
-export default App

--- a/vit/src/pages/BotsList.jsx
+++ b/vit/src/pages/BotsList.jsx
@@ -20,7 +20,10 @@ export default function BotsList() {
 
     return (
         <Stack spacing={3} sx={{ maxWidth: 900, mx: 'auto', my: 4 }}>
-            <Typography variant="h5">Your Bots</Typography>
+            <Stack direction="row" justifyContent="space-between" alignItems="center">
+                <Typography variant="h5">Your Bots</Typography>
+                <Button variant="contained" href="/admin/create">New Bot</Button>
+            </Stack>
             {bots.map(b => (
                 <Stack key={b._id} direction="row" spacing={2} alignItems="center">
                     <Typography sx={{ minWidth: 220 }}>{b.name}</Typography>

--- a/vit/src/pages/CreateBot.jsx
+++ b/vit/src/pages/CreateBot.jsx
@@ -23,10 +23,12 @@ export default function CreateBot() {
             questions
         });
         alert('Bot created: ' + bot._id);
+        window.location.href = '/admin';
     }
 
     return (
         <Stack spacing={2} sx={{ maxWidth: 640, mx: 'auto', my: 4 }}>
+            <Button href="/admin" variant="text">Back to Bots</Button>
             <TextField label="Bot Name" value={name} onChange={e => setName(e.target.value)} />
             <TextField label="Brand Color" value={primaryColor} onChange={e => setPrimaryColor(e.target.value)} />
             <TextField label="Launcher Text" value={launcherText} onChange={e => setLauncherText(e.target.value)} />

--- a/vit/vite.config.js
+++ b/vit/vite.config.js
@@ -1,7 +1,19 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react-swc'
+import { resolve } from 'path'
 
-// https://vite.dev/config/
+// Build the widget app and the embeddable loader script
 export default defineConfig({
   plugins: [react()],
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        loader: resolve(__dirname, 'src/bootstrap.js')
+      },
+      output: {
+        entryFileNames: (chunk) => chunk.name === 'loader' ? 'loader.js' : 'assets/[name]-[hash].js'
+      }
+    }
+  }
 })


### PR DESCRIPTION
## Summary
- serve widget bundle from vit/dist and expose loader script
- add Vite config to build loader and widget assets
- add minimal admin UI routing to create and list bots

## Testing
- `cd vit && npm test`
- `cd vit && npm run build`
- `cd BE && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899943a09a88322a2aab90412f4e1cf